### PR TITLE
Update Cloudflare link in App.vue

### DIFF
--- a/app/frontend/src/App.vue
+++ b/app/frontend/src/App.vue
@@ -90,7 +90,7 @@
 
         </CardFooter>
         <div class="flex items-center justify-center" style="font-size: 0.65em">
-          <a href="https://one.dash.cloudflare.com" target="_blank" class="inline-flex items-center">
+          <a href="https://dash.cloudflare.com/one/" target="_blank" class="inline-flex items-center">
             <img src="https://raw.githubusercontent.com/rdimascio/icons/master/icons/cloudflare.svg" class="w-[20px] mr-1" alt="Cloudflare Logo">
             {{ $t('ZeroTrust Dashboard') }}
           </a>


### PR DESCRIPTION
Dashboard now lives at new link. Old one works bu redirect but you have to wait 10s to get in

<img width="1413" height="1114" alt="image" src="https://github.com/user-attachments/assets/ab690ea8-8c73-41bf-b004-45f816d3c172" />
